### PR TITLE
adding another bucket for raw data vertica backups

### DIFF
--- a/nubis/terraform/consul.tf
+++ b/nubis/terraform/consul.tf
@@ -48,4 +48,9 @@ resource "consul_keys" "config" {
     value  = "${module.archive.name}"
     delete = true
   }
+  key {
+    path   = "${module.consul.config_prefix}/S3/Bucket/BackupRawData"
+    value  = "${module.backup_rawdata.name}"
+    delete = true
+  }
 }

--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -24,3 +24,14 @@ module "archive" {
   purpose      = "archive"
   role         = "${module.worker.role}"
 }
+
+module "backup_rawdata" {
+  source       = "github.com/nubisproject/nubis-terraform//bucket?ref=v2.2.0"
+  region       = "${var.region_second}"
+  environment  = "${var.environment}"
+  account      = "${var.account}"
+  service_name = "${var.service_name}"
+  purpose      = "backup_rawdata"
+  role_cnt     = "${length(data.aws_availability_zones.available.names)}"
+  role         = "${module.worker.role}"
+}

--- a/nubis/terraform/variables.tf
+++ b/nubis/terraform/variables.tf
@@ -4,6 +4,10 @@ variable "region" {
   default = "us-west-2"
 }
 
+variable "region_second" {
+  default = "us-east-1"
+}
+
 variable "arena" {
   default = "core"
 }


### PR DESCRIPTION
I thought about adding this bucket to "vertical" and "vertical-admin" but figured it made the most sense in "vertical-etl".
I figure we'll set up a cron to dump tables to this bucket on some schedule

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gozer/vertical-etl/3)
<!-- Reviewable:end -->
