### PR TITLE
Switch adi data load from copy_adi_dimensional_by_date_s3 table to co…

### DIFF
--- a/nubis/files/adi/load.py
+++ b/nubis/files/adi/load.py
@@ -67,7 +67,7 @@ def read_meta(input_file):
 
 def main(start_date, end_date):
     input_file = '/var/lib/etl/adi/' + start_date.strftime('%Y-%m-%d') + '/output'
-    vertica_table_name = 'copy_adi_dimensional_by_date_s3'
+    vertica_table_name = 'copy_adi_dimensional_by_date'
 
     # process/transform/aggregate input data
     logger.debug('transforming data')

--- a/nubis/files/adi/load.py
+++ b/nubis/files/adi/load.py
@@ -108,7 +108,7 @@ def main(start_date, end_date):
 
     # update last_updated with result
     logger.debug('inserting completed load in last_updated for monitoring')
-    last_updated_sql = ("insert into last_updated values ('copy_adi_dimensional_by_date_s3', now(), '%s');" % __file__)
+    last_updated_sql = ("insert into last_updated values ('copy_adi_dimensional_by_date', now(), '%s');" % __file__)
     query_vertica(last_updated_sql)
     
     # All worked, commit it all


### PR DESCRIPTION
…py_adi_dimensional_by_date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gozer/vertical-etl/20)
<!-- Reviewable:end -->
